### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *~
 /django_info_pages.egg-info
+/file_archive/

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'django-file-archive==0.0.2',
         'django-pagination==1.0.7',
         'django-slug-helpers>=0.0.3',
+        'six==1.10.0'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
The version of django-autocomplete-light we're using (2.3.3) only works with six <= 1.10.0, so pin to that version to get the tests passing again.

Fixes #6 