### PR TITLE
Updates for Django 1.11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
-env:
-  - DJANGO_VERSION='>=1.8,<1.9'
 install:
-  - "pip install Django$DJANGO_VERSION"
   - "pip install -e ."
   - "pip install coverage python-coveralls"
 script:

--- a/info/migration_helpers.py
+++ b/info/migration_helpers.py
@@ -20,7 +20,7 @@ def get_first_image_file(file_archive_file_class, info_page):
         html = info_page.raw_content
     else:
         html = markdown(unicode(info_page.markdown_content))
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, features='lxml')
     imgs = soup.find_all('img')
     if not imgs:
         return None

--- a/info/urls/blog.py
+++ b/info/urls/blog.py
@@ -1,13 +1,11 @@
-from django.conf.urls import patterns, url, handler404
+from django.conf.urls import url
 
 from ..views import InfoBlogView, InfoBlogList, InfoBlogFeed, InfoBlogCategory, InfoBlogTag
 
-
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', InfoBlogList.as_view(), name='info_blog_list'),
     url(r'^category/(?P<slug>[\w\-,]+)$', InfoBlogCategory.as_view(), name='info_blog_category'),
     url(r'^tag/(?P<slug>[\w\-,]+)$',      InfoBlogTag.as_view(),      name='info_blog_tag'),
     url(r'^feed\.rss$', InfoBlogFeed(), name='info_blog_feed'),
     url(r'^(?P<slug>[\w\-]+)$', InfoBlogView.as_view(), name='info_blog'),
-    url(r'^.*$', handler404),
-)
+]

--- a/info/urls/pages.py
+++ b/info/urls/pages.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url, handler404
+from django.conf.urls import url
 
 from ..views import InfoPageView
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$',                  InfoPageView.as_view(), { 'slug': 'index' } ),
     url(r'^(?P<slug>[\w\-]+)$', InfoPageView.as_view(), name='info_page' ),
-    url(r'^.*$',                handler404    ),
-)
+]

--- a/runtests.py
+++ b/runtests.py
@@ -28,9 +28,20 @@ if not settings.configured:
         SITE_ID=1,
         SECRET_KEY='this-is-just-for-tests-so-not-that-secret',
         ROOT_URLCONF='info.urls',
-        TEMPLATE_DIRS=(
-            realpath(join(dirname(__file__), 'example_templates')),
-        ),
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [
+                    realpath(join(dirname(__file__), 'example_templates'))
+                ],
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'context_processors': [
+                        'django.contrib.auth.context_processors.auth',
+                    ],
+                },
+            },
+        ],
         MARKITUP_FILTER=(
             'markdown.markdown',
             {'safe_mode': True, 'extensions':['tables']}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     keywords = "django blog cms",
     include_package_data=True,
     install_requires = [
-        'Django>=1.8.12,<1.9',
+        'Django>=1.8.12,<2',
         'beautifulsoup4',
         'lxml',
         'Markdown',
@@ -30,7 +30,7 @@ setup(
         'nose',
         'django-autocomplete-light==2.3.3',
         'django-file-archive==0.0.2',
-        'django-pagination==1.0.7',
+        'mysociety-django-pagination==1.0.8',
         'django-slug-helpers>=0.0.3',
         'six==1.10.0'
     ],


### PR DESCRIPTION
Updates that were necessary to get the tests passing under Django 1.11.20.

- Forked [django-pagination](https://github.com/ericflo/django-pagination), updated it to be Django 1.11 compatible (https://github.com/mysociety/django-pagination/pull/1) and released to PyPi as [`mysociety-django-pagination` v1.0.9](https://pypi.org/project/mysociety-django-pagination/).

Fixes https://github.com/mysociety/django-info-pages/issues/9